### PR TITLE
Added AdapterOptions struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ opts := &AdapterOptions{
     DataSourceName: "root:1234@tcp(127.0.0.1:3306)/yourdb",
     TableName: "casbin_rule",
     // or reuse an existing connection:
-    // Db: myDBConn,
+    // DB: myDBConn,
 }
 
 a := NewAdapterFromOptions(opts)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ Based on [sqlx](https://github.com/jmoiron/sqlx), and tested in [MySQL](https://
 
     go get github.com/memwey/casbin-sqlx-adapter
 
+## Usage example
+
+```go
+opts := &AdapterOptions{
+    DriverName: "mysql",
+    DataSourceName: "root:1234@tcp(127.0.0.1:3306)/yourdb",
+    TableName: "casbin_rule",
+    // or reuse an existing connection:
+    // Db: myDBConn,
+}
+
+a := NewAdapterFromOptions(opts)
+e := casbin.NewEnforcer("examples/rbac_model.conf", a)
+```
+
 ## Notice
 
 The implement is kind of different from the [official one](https://casbin.org/docs/en/adapters). In this implement you should create the database and table on your own.

--- a/adapter.go
+++ b/adapter.go
@@ -23,16 +23,16 @@ type CasbinRule struct {
 
 // Adapter represents the sqlx adapter for policy storage.
 type Adapter struct {
-	db *sqlx.DB
+	db        *sqlx.DB
 	tableName string
 }
 
 // AdapterOptions contains all possible configuration options.
 type AdapterOptions struct {
-	DriverName string
+	DriverName     string
 	DataSourceName string
-	TableName string
-	Db *sqlx.DB
+	TableName      string
+	DB             *sqlx.DB
 }
 
 func finalizer(a *Adapter) {
@@ -128,7 +128,7 @@ func NewAdapter(driverName string, dataSourceName string) *Adapter {
 		panic(err)
 	}
 	a := &Adapter{
-		db: db,
+		db:        db,
 		tableName: "casbin_rule",
 	}
 	a.ensureTable()
@@ -140,7 +140,7 @@ func NewAdapter(driverName string, dataSourceName string) *Adapter {
 // NewAdapterByDB is the constructor for Adapter with existed connection
 func NewAdapterByDB(db *sqlx.DB) *Adapter {
 	a := &Adapter{
-		db: db,
+		db:        db,
 		tableName: "casbin_rule",
 	}
 	a.ensureTable()
@@ -155,8 +155,8 @@ func NewAdapterFromOptions(opts *AdapterOptions) *Adapter {
 		a.tableName = opts.TableName
 	}
 
-	if opts.Db != nil {
-		a.db = opts.Db
+	if opts.DB != nil {
+		a.db = opts.DB
 	} else {
 		db, err := sqlx.Connect(opts.DriverName, opts.DataSourceName)
 		if err != nil {


### PR DESCRIPTION
This PR adds the ability to create an adapter using a new AdapterOptions struct. This  is a more forewards compatible approach to constructors.

```go
opts := AdapterOptions{
    db: myDBConn,
    // driverName: "mysql",
    // dataSourceName: "root@...", 
    tableName: "policies",
}

a := NewAdapterFromOptions(opts)
```

This particualar PR adds the ability to specify a custom table name since some frameworks and tools require the table names to follow certain rules.



I have added this functionality for my own use. Merge if you are interested to include it in the adapter or close otherwise!

This PR also contains the changes from #3 